### PR TITLE
feat: cmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:12
 # https://askubuntu.com/a/577334
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  cmake \
   build-essential \
   qtbase5-dev \
   libqt5x11extras5-dev \


### PR DESCRIPTION
Due to [@nodegui/nodegui](https://github.com/nodegui/nodegui/releases/tag/v0.2.0) using CMake as build system instead of node-gyp, CMake should be installed as a dependency